### PR TITLE
Fix route to posts collection

### DIFF
--- a/resources/views/widgets/getting-started.blade.php
+++ b/resources/views/widgets/getting-started.blade.php
@@ -13,7 +13,7 @@
                 <p>Customize your site name, tagline, social links, and copyright info.</p>
             </div>
         </a>
-        <a href="{{ cp_route('collections.entries.index', 'posts') }}" class="p-2 flex items-start hover:bg-blue-100 rounded-md group">
+        <a href="{{ cp_route('collections.show', 'posts') }}" class="p-2 flex items-start hover:bg-blue-100 rounded-md group">
             <div class="h-12 w-12 mr-3 text-blue-900 rounded-full bg-blue-100 group-hover:bg-blue-200 p-1">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><g transform="scale(1.33333)"><path d="M15.543 15.543l-2.628-6.571c-.2-.511-.558-.519-.785-.018l-2.087 4.589-1.859-2.231a.667.667 0 00-1.155.089l-2.486 4.142" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/><rect x="1.543" y="1.543" width="17" height="17" rx="1" ry="1" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/><path d="M20.551 7.424l1 .091a1 1 0 01.901 1.085l-1.181 12.948a1 1 0 01-1.087.9L6.243 21.18M1.543 15.543h17" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/><circle cx="6.043" cy="6.043" r="1.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></g></svg>
             </div>


### PR DESCRIPTION
Previously it was pointing to a JSON endpoint, now it actually points to the collection's show page (which shows the collection's entries)