### PR TITLE
Fix site.css import

### DIFF
--- a/resources/css/tailwind.css
+++ b/resources/css/tailwind.css
@@ -1,6 +1,6 @@
-@import "tailwindcss/base";
-
 @import "site";
+
+@import "tailwindcss/base";
 
 @import "tailwindcss/components";
 


### PR DESCRIPTION
@import statement must come first to be recognized. Should work with the @import coming later, but doesn't. Might be related to the @tailwind declaration in the 'tailwind/base' file that's imported before.