### PR TITLE
Fix social link displaying when value in global set to null

### DIFF
--- a/resources/views/partials/_nav.antlers.html
+++ b/resources/views/partials/_nav.antlers.html
@@ -9,9 +9,11 @@
         <nav>
             <ul class="flex items-center space-x-6">
                 {{ foreach:social_links }}
-                    <a href="{{ value }}" class="flex items-center justify-center h-7 w-7 hover:text-indigo-800 scale-100 hover:scale-[1.1] hover:-rotate-2" title="{{ label }}">
-                        {{ svg src="assets/icons/{key}" :aria-label="label" role="img" }}
-                    </a>
+                    {{ if value }}
+                        <a href="{{ value }}" class="flex items-center justify-center h-7 w-7 hover:text-indigo-800 scale-100 hover:scale-[1.1] hover:-rotate-2" title="{{ label }}">
+                            {{ svg src="assets/icons/{key}" :aria-label="label" role="img" }}
+                        </a>
+                    {{ /if }}
                 {{ /foreach:social_links }}
                 <li>
                     <a href="/feed.xml">


### PR DESCRIPTION
This fixes an issue I found here if you save the globals in the Statamic UI, all of the social icons would appear, even the ones you didn't have values for.  This appears to be because when saving in Statmic 5, it sets all of them to `null`, which adds in the properties that didn't have values before, even if they werent in the file at all before

Steps to reproduce:
1. Start with a globals file with just a few socials set:
```
  social_links:
    email: 'mailto:name@example.com'
    facebook: facebook.com/name
  copyright:
```
2. Go to the Globals page in the control panel UI, click save
3. Confirm that the rest of the social links were populated in the file as `null`
4. View the site, it will (incorrectly) show ALL the social links at the top.