### PR TITLE
Fix Tailwind CSS not building correctly

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+    plugins: {
+        tailwindcss: {},
+        autoprefixer: {},
+    },
+}


### PR DESCRIPTION
This pull request fixes an issue where Tailwind CSS wasn't building correctly after the `postcss.config.js` file was deleted in https://github.com/statamic/statamic/pull/93.